### PR TITLE
implement Paralax Background

### DIFF
--- a/Assets/Scenes/Scence1.unity
+++ b/Assets/Scenes/Scence1.unity
@@ -987,93 +987,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &788632204
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 788632205}
-  - component: {fileID: 788632206}
-  m_Layer: 0
-  m_Name: 0_0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &788632205
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 788632204}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1795868595}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &788632206
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 788632204}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -828366041, guid: 22d892a4b748b8e4c9812b1c35bcce14, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 2
-  m_Size: {x: 125, y: 20}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 1
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &856648099
 GameObject:
   m_ObjectHideFlags: 0
@@ -10134,7 +10047,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 788632205}
   - {fileID: 2083571350}
   - {fileID: 1172193137}
   - {fileID: 856648100}
@@ -10287,6 +10199,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2083571350}
   - component: {fileID: 2083571351}
+  - component: {fileID: 2083571352}
   m_Layer: 0
   m_Name: 7_0
   m_TagString: Untagged
@@ -10364,6 +10277,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &2083571352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083571349}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 0}
+  followTarget: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Scence1.unity
+++ b/Assets/Scenes/Scence1.unity
@@ -129,6 +129,7 @@ GameObject:
   m_Component:
   - component: {fileID: 187373879}
   - component: {fileID: 187373880}
+  - component: {fileID: 187373881}
   m_Layer: 0
   m_Name: 4_0
   m_TagString: Untagged
@@ -145,7 +146,7 @@ Transform:
   m_GameObject: {fileID: 187373878}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -0.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -206,6 +207,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &187373881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187373878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1 &213619072 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 672597975836069524, guid: 3cc61b8e0472e554ab8525a307c336ec, type: 3}
@@ -238,8 +253,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6964c86ab76ed4b4abd23b83334b589f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  startingPoint: {fileID: 680376959}
-  gameGroundLayer: 6
 --- !u!1 &342725285
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,6 +341,7 @@ GameObject:
   m_Component:
   - component: {fileID: 442791529}
   - component: {fileID: 442791530}
+  - component: {fileID: 442791531}
   m_Layer: 0
   m_Name: 3_0
   m_TagString: Untagged
@@ -344,7 +358,7 @@ Transform:
   m_GameObject: {fileID: 442791528}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -405,6 +419,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &442791531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442791528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1 &484265813
 GameObject:
   m_ObjectHideFlags: 0
@@ -415,6 +443,7 @@ GameObject:
   m_Component:
   - component: {fileID: 484265814}
   - component: {fileID: 484265815}
+  - component: {fileID: 484265816}
   m_Layer: 0
   m_Name: 2_0
   m_TagString: Untagged
@@ -431,7 +460,7 @@ Transform:
   m_GameObject: {fileID: 484265813}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -492,6 +521,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &484265816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 484265813}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -997,6 +1040,7 @@ GameObject:
   m_Component:
   - component: {fileID: 856648100}
   - component: {fileID: 856648101}
+  - component: {fileID: 856648102}
   m_Layer: 0
   m_Name: 5_0
   m_TagString: Untagged
@@ -1013,7 +1057,7 @@ Transform:
   m_GameObject: {fileID: 856648099}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1074,6 +1118,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &856648102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 856648099}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1 &951063949
 GameObject:
   m_ObjectHideFlags: 0
@@ -1084,6 +1142,7 @@ GameObject:
   m_Component:
   - component: {fileID: 951063950}
   - component: {fileID: 951063951}
+  - component: {fileID: 951063952}
   m_Layer: 0
   m_Name: 1_1
   m_TagString: Untagged
@@ -1100,7 +1159,7 @@ Transform:
   m_GameObject: {fileID: 951063949}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -0.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1161,6 +1220,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &951063952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 951063949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1 &967991658
 GameObject:
   m_ObjectHideFlags: 0
@@ -8923,6 +8996,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1172193137}
   - component: {fileID: 1172193138}
+  - component: {fileID: 1172193139}
   m_Layer: 0
   m_Name: 6_0
   m_TagString: Untagged
@@ -8939,7 +9013,7 @@ Transform:
   m_GameObject: {fileID: 1172193136}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -1.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -9000,6 +9074,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1172193139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172193136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
 --- !u!1001 &1221576615
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10200,6 +10288,7 @@ GameObject:
   - component: {fileID: 2083571350}
   - component: {fileID: 2083571351}
   - component: {fileID: 2083571352}
+  - component: {fileID: 2083571353}
   m_Layer: 0
   m_Name: 7_0
   m_TagString: Untagged
@@ -10216,7 +10305,7 @@ Transform:
   m_GameObject: {fileID: 2083571349}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -0.24, z: 0}
+  m_LocalPosition: {x: 2, y: -0.24, z: -1.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10278,6 +10367,20 @@ SpriteRenderer:
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &2083571352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083571349}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 643861416}
+  followTarget: {fileID: 259172382}
+--- !u!114 &2083571353
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Scenes/Scence2.unity
+++ b/Assets/Scenes/Scence2.unity
@@ -129,6 +129,7 @@ GameObject:
   m_Component:
   - component: {fileID: 205862360}
   - component: {fileID: 205862361}
+  - component: {fileID: 205862362}
   m_Layer: 6
   m_Name: 2_0
   m_TagString: Untagged
@@ -145,7 +146,7 @@ Transform:
   m_GameObject: {fileID: 205862359}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -206,6 +207,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &205862362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 205862359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1001 &226790347
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -397,6 +412,7 @@ GameObject:
   m_Component:
   - component: {fileID: 369949766}
   - component: {fileID: 369949767}
+  - component: {fileID: 369949768}
   m_Layer: 6
   m_Name: 4_0
   m_TagString: Untagged
@@ -413,7 +429,7 @@ Transform:
   m_GameObject: {fileID: 369949765}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -474,6 +490,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &369949768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369949765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1 &473455998
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,6 +514,7 @@ GameObject:
   m_Component:
   - component: {fileID: 473455999}
   - component: {fileID: 473456000}
+  - component: {fileID: 473456001}
   m_Layer: 6
   m_Name: 6_0
   m_TagString: Untagged
@@ -500,7 +531,7 @@ Transform:
   m_GameObject: {fileID: 473455998}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -561,6 +592,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &473456001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 473455998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1001 &488879354
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -791,7 +836,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 693347797}
   - {fileID: 1481409613}
   - {fileID: 473455999}
   - {fileID: 964049931}
@@ -801,93 +845,6 @@ Transform:
   - {fileID: 1705594762}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &693347796
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 693347797}
-  - component: {fileID: 693347798}
-  m_Layer: 6
-  m_Name: 0_0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &693347797
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 693347796}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 646712468}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &693347798
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 693347796}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -828366041, guid: 22d892a4b748b8e4c9812b1c35bcce14, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 2
-  m_Size: {x: 100, y: 25}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 1
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &964049930
 GameObject:
   m_ObjectHideFlags: 0
@@ -898,6 +855,7 @@ GameObject:
   m_Component:
   - component: {fileID: 964049931}
   - component: {fileID: 964049932}
+  - component: {fileID: 964049933}
   m_Layer: 6
   m_Name: 5_0
   m_TagString: Untagged
@@ -914,7 +872,7 @@ Transform:
   m_GameObject: {fileID: 964049930}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -975,6 +933,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &964049933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964049930}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1 &1015662712
 GameObject:
   m_ObjectHideFlags: 0
@@ -10408,6 +10380,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1344438864}
   - component: {fileID: 1344438865}
+  - component: {fileID: 1344438866}
   m_Layer: 6
   m_Name: 3_0
   m_TagString: Untagged
@@ -10424,7 +10397,7 @@ Transform:
   m_GameObject: {fileID: 1344438863}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10485,6 +10458,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1344438866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1344438863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1 &1481409612
 GameObject:
   m_ObjectHideFlags: 0
@@ -10495,6 +10482,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1481409613}
   - component: {fileID: 1481409614}
+  - component: {fileID: 1481409615}
   m_Layer: 6
   m_Name: 7_0
   m_TagString: Untagged
@@ -10511,7 +10499,7 @@ Transform:
   m_GameObject: {fileID: 1481409612}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -2.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10572,6 +10560,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1481409615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1481409612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1001 &1490138757
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10643,6 +10645,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1705594762}
   - component: {fileID: 1705594763}
+  - component: {fileID: 1705594764}
   m_Layer: 6
   m_Name: 1_1
   m_TagString: Untagged
@@ -10659,7 +10662,7 @@ Transform:
   m_GameObject: {fileID: 1705594761}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10720,6 +10723,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1705594764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705594761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1110748335}
+  followTarget: {fileID: 1192457488}
 --- !u!1 &2010895745
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Scence3.unity
+++ b/Assets/Scenes/Scence3.unity
@@ -129,6 +129,7 @@ GameObject:
   m_Component:
   - component: {fileID: 331234058}
   - component: {fileID: 331234059}
+  - component: {fileID: 331234060}
   m_Layer: 6
   m_Name: 7_0
   m_TagString: Untagged
@@ -145,7 +146,7 @@ Transform:
   m_GameObject: {fileID: 331234057}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -2.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -206,6 +207,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &331234060
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331234057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &494985982
 GameObject:
   m_ObjectHideFlags: 0
@@ -10040,6 +10055,7 @@ GameObject:
   m_Component:
   - component: {fileID: 536560611}
   - component: {fileID: 536560612}
+  - component: {fileID: 536560613}
   m_Layer: 6
   m_Name: 4_0
   m_TagString: Untagged
@@ -10056,7 +10072,7 @@ Transform:
   m_GameObject: {fileID: 536560610}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10117,6 +10133,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &536560613
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536560610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &549608499
 GameObject:
   m_ObjectHideFlags: 0
@@ -10127,6 +10157,7 @@ GameObject:
   m_Component:
   - component: {fileID: 549608500}
   - component: {fileID: 549608501}
+  - component: {fileID: 549608502}
   m_Layer: 6
   m_Name: 1_1
   m_TagString: Untagged
@@ -10143,7 +10174,7 @@ Transform:
   m_GameObject: {fileID: 549608499}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10204,6 +10235,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &549608502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549608499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &583790071
 GameObject:
   m_ObjectHideFlags: 0
@@ -10289,7 +10334,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1453301456}
   - {fileID: 331234058}
   - {fileID: 1687939969}
   - {fileID: 761964523}
@@ -10393,6 +10437,7 @@ GameObject:
   m_Component:
   - component: {fileID: 761964523}
   - component: {fileID: 761964524}
+  - component: {fileID: 761964525}
   m_Layer: 6
   m_Name: 5_0
   m_TagString: Untagged
@@ -10409,7 +10454,7 @@ Transform:
   m_GameObject: {fileID: 761964522}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10470,6 +10515,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &761964525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761964522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &831348081
 GameObject:
   m_ObjectHideFlags: 0
@@ -10840,93 +10899,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b26ec57205e2e0c41b04a8bc53dab61b, type: 3}
---- !u!1 &1453301455
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1453301456}
-  - component: {fileID: 1453301457}
-  m_Layer: 6
-  m_Name: 0_0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1453301456
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1453301455}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 583790073}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1453301457
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1453301455}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -828366041, guid: 22d892a4b748b8e4c9812b1c35bcce14, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 2
-  m_Size: {x: 125, y: 25}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 1
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1001 &1475199600
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11612,6 +11584,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1654828565}
   - component: {fileID: 1654828566}
+  - component: {fileID: 1654828567}
   m_Layer: 6
   m_Name: 3_0
   m_TagString: Untagged
@@ -11628,7 +11601,7 @@ Transform:
   m_GameObject: {fileID: 1654828564}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -1.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -11689,6 +11662,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1654828567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1654828564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &1672827302
 GameObject:
   m_ObjectHideFlags: 0
@@ -11699,6 +11686,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1672827303}
   - component: {fileID: 1672827304}
+  - component: {fileID: 1672827305}
   m_Layer: 6
   m_Name: 2_0
   m_TagString: Untagged
@@ -11715,7 +11703,7 @@ Transform:
   m_GameObject: {fileID: 1672827302}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -11776,6 +11764,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1672827305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1672827302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &1687939968
 GameObject:
   m_ObjectHideFlags: 0
@@ -11786,6 +11788,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1687939969}
   - component: {fileID: 1687939970}
+  - component: {fileID: 1687939971}
   m_Layer: 6
   m_Name: 6_0
   m_TagString: Untagged
@@ -11802,7 +11805,7 @@ Transform:
   m_GameObject: {fileID: 1687939968}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -2.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -11863,6 +11866,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1687939971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1687939968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 942884196}
+  followTarget: {fileID: 1475199603}
 --- !u!1 &1865091443
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Scence4.unity
+++ b/Assets/Scenes/Scence4.unity
@@ -301,7 +301,7 @@ GameObject:
   - component: {fileID: 163654581}
   - component: {fileID: 163654580}
   - component: {fileID: 163654579}
-  m_Layer: 3
+  m_Layer: 6
   m_Name: Road
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4757,6 +4757,7 @@ GameObject:
   m_Component:
   - component: {fileID: 382846107}
   - component: {fileID: 382846108}
+  - component: {fileID: 382846109}
   m_Layer: 6
   m_Name: 6_0
   m_TagString: Untagged
@@ -4773,7 +4774,7 @@ Transform:
   m_GameObject: {fileID: 382846106}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -2.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4834,6 +4835,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &382846109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 382846106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1001 &463106837
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4916,8 +4931,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 472888651}
     - target: {fileID: 7342960616324395584, guid: 3cc61b8e0472e554ab8525a307c336ec, type: 3}
+      propertyPath: m_SortingLayer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7342960616324395584, guid: 3cc61b8e0472e554ab8525a307c336ec, type: 3}
       propertyPath: m_SortingOrder
       value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7342960616324395584, guid: 3cc61b8e0472e554ab8525a307c336ec, type: 3}
+      propertyPath: m_SortingLayerID
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797637335284552775, guid: 3cc61b8e0472e554ab8525a307c336ec, type: 3}
       propertyPath: m_LocalScale.x
@@ -5005,6 +5028,7 @@ GameObject:
   m_Component:
   - component: {fileID: 765002349}
   - component: {fileID: 765002350}
+  - component: {fileID: 765002351}
   m_Layer: 6
   m_Name: 2_0
   m_TagString: Untagged
@@ -5021,7 +5045,7 @@ Transform:
   m_GameObject: {fileID: 765002348}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5082,6 +5106,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &765002351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765002348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1 &825292743
 GameObject:
   m_ObjectHideFlags: 0
@@ -5092,6 +5130,7 @@ GameObject:
   m_Component:
   - component: {fileID: 825292744}
   - component: {fileID: 825292745}
+  - component: {fileID: 825292746}
   m_Layer: 6
   m_Name: 7_0
   m_TagString: Untagged
@@ -5108,7 +5147,7 @@ Transform:
   m_GameObject: {fileID: 825292743}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5169,6 +5208,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &825292746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825292743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1 &1202286502
 GameObject:
   m_ObjectHideFlags: 0
@@ -5179,6 +5232,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1202286503}
   - component: {fileID: 1202286504}
+  - component: {fileID: 1202286505}
   m_Layer: 6
   m_Name: 1_1
   m_TagString: Untagged
@@ -5195,7 +5249,7 @@ Transform:
   m_GameObject: {fileID: 1202286502}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -0.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5256,6 +5310,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1202286505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1202286502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1 &1283290992
 GameObject:
   m_ObjectHideFlags: 0
@@ -5266,6 +5334,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1283290993}
   - component: {fileID: 1283290994}
+  - component: {fileID: 1283290995}
   m_Layer: 6
   m_Name: 3_0
   m_TagString: Untagged
@@ -5282,7 +5351,7 @@ Transform:
   m_GameObject: {fileID: 1283290992}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -0.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5343,6 +5412,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1283290995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1283290992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1 &1315940585
 GameObject:
   m_ObjectHideFlags: 0
@@ -5428,7 +5511,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2074818050}
   - {fileID: 825292744}
   - {fileID: 382846107}
   - {fileID: 1933452020}
@@ -5788,6 +5870,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1933452020}
   - component: {fileID: 1933452021}
+  - component: {fileID: 1933452022}
   m_Layer: 6
   m_Name: 5_0
   m_TagString: Untagged
@@ -5804,7 +5887,7 @@ Transform:
   m_GameObject: {fileID: 1933452019}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5865,6 +5948,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1933452022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1933452019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1 &1970021987
 GameObject:
   m_ObjectHideFlags: 0
@@ -6150,93 +6247,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2074818049
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2074818050}
-  - component: {fileID: 2074818051}
-  m_Layer: 6
-  m_Name: 0_0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2074818050
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074818049}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1315940587}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2074818051
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074818049}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -828366041, guid: 22d892a4b748b8e4c9812b1c35bcce14, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 2
-  m_Size: {x: 100, y: 25}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 1
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &2112102025
 GameObject:
   m_ObjectHideFlags: 0
@@ -6367,6 +6377,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2145822455}
   - component: {fileID: 2145822456}
+  - component: {fileID: 2145822457}
   m_Layer: 6
   m_Name: 4_0
   m_TagString: Untagged
@@ -6383,7 +6394,7 @@ Transform:
   m_GameObject: {fileID: 2145822454}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -17.5, y: 0, z: 0}
+  m_LocalPosition: {x: -17.5, y: 0, z: -1.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6444,6 +6455,20 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &2145822457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145822454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d5c95740ed28e54a979968480b47847, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 33763290}
+  followTarget: {fileID: 472888653}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ParalaxEffect.cs
+++ b/Assets/Scripts/ParalaxEffect.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class ParalaxEffect : MonoBehaviour
+{
+    public Camera cam;
+    public Transform followTarget;
+
+    // Vị trí bắt đầu cho hiệu ứng parallax
+    Vector2 startingPosition;
+
+    // Giá trị Z bắt đầu của đối tượng parallax
+    float startingZ;
+
+    // Khoảng cách mà camera đã di chuyển từ vị trí bắt đầu của đối tượng parallax
+    Vector2 camMoveSinceStart => (Vector2)cam.transform.position - startingPosition;
+
+    float zDistanceFromTarget => transform.position.z - followTarget.transform.position.z;
+
+    // Nếu đối tượng ở phía trước mục tiêu, sử dụng near clip plane. Nếu sau mục tiêu, sử dụng farClipPlane
+    float clippingPlane => (cam.transform.position.z + (zDistanceFromTarget > 0 ? cam.farClipPlane : cam.nearClipPlane));
+
+    // Đối tượng càng xa người chơi, hiệu ứng ParallaxEffect sẽ di chuyển càng nhanh. Kéo giá trị Z gần mục tiêu hơn để làm cho nó di chuyển chậm hơn.
+    float parallaxFactor => Mathf.Abs(zDistanceFromTarget) / clippingPlane;
+
+    // Start được gọi một lần trước khi thực thi Update đầu tiên sau khi MonoBehaviour được tạo
+    void Start()
+    {
+        startingPosition = transform.position;
+        startingZ = transform.position.z;
+    }
+
+    // Update được gọi một lần mỗi frame
+    void Update()
+    {
+        // Khi mục tiêu di chuyển, di chuyển đối tượng parallax cùng khoảng cách nhân với một hệ số
+        Vector2 newPosition = startingPosition + camMoveSinceStart * parallaxFactor;
+
+        // Vị trí X/Y thay đổi dựa trên tốc độ di chuyển của mục tiêu nhân với hệ số parallax, nhưng Z giữ nguyên
+        transform.position = new Vector3(newPosition.x, newPosition.y, startingZ);
+    }
+}

--- a/Assets/Scripts/ParalaxEffect.cs.meta
+++ b/Assets/Scripts/ParalaxEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d5c95740ed28e54a979968480b47847


### PR DESCRIPTION
This pull request includes updates to the Unity scene files `Scence1.unity` and `Scence2.unity`. The major changes involve adjustments to object positions, additions of new components, and modifications to `SpriteRenderer` and `MonoBehaviour` properties. Below is a summary of the most important changes grouped by theme:

### Object Position Updates:
* Adjusted the `m_LocalPosition.z` values for multiple objects across both scenes to reposition them along the Z-axis. For example, object `4_0` in `Scence1.unity` was moved from `z: 0` to `z: -0.8` [[1]](diffhunk://#diff-b934efa582a08d55838b72d4c3477ec0a8743df0b8b8d14cf824f2fa79bfc8c0L148-R149) and object `2_0` in `Scence2.unity` was moved from `z: 0` to `z: -0.6` [[2]](diffhunk://#diff-6e0b2818f092bc017d22c7a3f8be010d942a2a89f10c75773e7e060a52c1c4c7L148-R149).

### Component Additions:
* Added new components to various `GameObject` instances, such as `component: {fileID: 187373881}` to `4_0` in `Scence1.unity` [[1]](diffhunk://#diff-b934efa582a08d55838b72d4c3477ec0a8743df0b8b8d14cf824f2fa79bfc8c0R132) and `component: {fileID: 205862362}` to `2_0` in `Scence2.unity` [[2]](diffhunk://#diff-6e0b2818f092bc017d22c7a3f8be010d942a2a89f10c75773e7e060a52c1c4c7R132).

### SpriteRenderer and MonoBehaviour Updates:
* Introduced new `SpriteRenderer` and `MonoBehaviour` configurations for several objects. For instance, a `MonoBehaviour` with `cam` and `followTarget` properties was added to `4_0` in `Scence1.unity` [[1]](diffhunk://#diff-b934efa582a08d55838b72d4c3477ec0a8743df0b8b8d14cf824f2fa79bfc8c0R210-R223) and `2_0` in `Scence2.unity` [[2]](diffhunk://#diff-6e0b2818f092bc017d22c7a3f8be010d942a2a89f10c75773e7e060a52c1c4c7R210-R223).

### Object Removals:
* Removed an entire `GameObject` hierarchy including its `Transform` and `SpriteRenderer` components, such as the object `0_0` in `Scence1.unity`.

### New Components with Multiple Scripts:
* Added multiple `MonoBehaviour` components to a single `GameObject`, such as `7_0` in `Scence1.unity`, which now includes two scripts with different `cam` and `followTarget` configurations.