### PR TITLE
refactor: remove unused buff start SFX from ArmorPickup and DamagePickup scripts

### DIFF
--- a/Assets/Scripts/Interactive/Items/ArmorPickup.cs
+++ b/Assets/Scripts/Interactive/Items/ArmorPickup.cs
@@ -11,8 +11,6 @@ namespace InteractiveItems
         public bool reduceByPercent = true;
         [Tooltip("Giá trị giảm damage (phần trăm hoặc số lượng cố định)")]
         public float reduceValue = 20f;
-        [Tooltip("SFX khi bắt đầu buff giáp (tùy chọn)")]
-        public AudioClip buffStartSFX;
         [Tooltip("SFX khi kết thúc buff giáp (tùy chọn)")]
         public AudioClip buffEndSFX;
         
@@ -26,7 +24,7 @@ namespace InteractiveItems
             var pc = player.GetComponent<PlayerController>();
             if (pc != null)
             {
-                pc.ApplyDefenseBuff(reduceByPercent, reduceValue, 0f, buffStartSFX, buffEndSFX);
+                pc.ApplyDefenseBuff(reduceByPercent, reduceValue, 0f, null, buffEndSFX);
             }
             
             // Thêm vào inventory
@@ -49,7 +47,7 @@ namespace InteractiveItems
             var pc = player.GetComponent<PlayerController>();
             if (pc != null)
             {
-                pc.ApplyDefenseBuff(reduceByPercent, reduceValue, buffDuration, buffStartSFX, buffEndSFX);
+                pc.ApplyDefenseBuff(reduceByPercent, reduceValue, buffDuration, null, buffEndSFX);
             }
             
             // Thêm vào inventory

--- a/Assets/Scripts/Interactive/Items/DamagePickup.cs
+++ b/Assets/Scripts/Interactive/Items/DamagePickup.cs
@@ -11,8 +11,6 @@ namespace InteractiveItems
         public bool increaseByPercent = true;
         [Tooltip("Giá trị tăng damage (phần trăm hoặc số lượng cố định)")]
         public float increaseValue = 20f;
-        [Tooltip("SFX khi bắt đầu buff damage (tùy chọn)")]
-        public AudioClip buffStartSFX;
         [Tooltip("SFX khi kết thúc buff damage (tùy chọn)")]
         public AudioClip buffEndSFX;
         
@@ -26,7 +24,7 @@ namespace InteractiveItems
             var pc = player.GetComponent<PlayerController>();
             if (pc != null)
             {
-                pc.ApplyDamageBuff(increaseByPercent, increaseValue, 0f, buffStartSFX, buffEndSFX);
+                pc.ApplyDamageBuff(increaseByPercent, increaseValue, 0f, null, buffEndSFX);
             }
             
             // Thêm vào inventory
@@ -49,7 +47,7 @@ namespace InteractiveItems
             var pc = player.GetComponent<PlayerController>();
             if (pc != null)
             {
-                pc.ApplyDamageBuff(increaseByPercent, increaseValue, buffDuration, buffStartSFX, buffEndSFX);
+                pc.ApplyDamageBuff(increaseByPercent, increaseValue, buffDuration, null, buffEndSFX);
             }
             
             // Thêm vào inventory


### PR DESCRIPTION
### Refactoring sound effect handling:

* [`Assets/Scripts/Interactive/Items/ArmorPickup.cs`](diffhunk://#diff-07811170431c17d040f504c90ef93889f427d1f3c09b124e6a77d9c76f1bd5ceL14-L15): Removed the `buffStartSFX` property and updated calls to `pc.ApplyDefenseBuff` to pass `null` instead of `buffStartSFX`. This affects both `OnPickupEffect` and `OnBuffStart` methods. [[1]](diffhunk://#diff-07811170431c17d040f504c90ef93889f427d1f3c09b124e6a77d9c76f1bd5ceL14-L15) [[2]](diffhunk://#diff-07811170431c17d040f504c90ef93889f427d1f3c09b124e6a77d9c76f1bd5ceL29-R27) [[3]](diffhunk://#diff-07811170431c17d040f504c90ef93889f427d1f3c09b124e6a77d9c76f1bd5ceL52-R50)

* [`Assets/Scripts/Interactive/Items/DamagePickup.cs`](diffhunk://#diff-66ba5e56c3998c8d71a8d1f3b0fa4486a4e5f2d82edea06cf5bb8312601deb00L14-L15): Removed the `buffStartSFX` property and updated calls to `pc.ApplyDamageBuff` to pass `null` instead of `buffStartSFX`. This affects both `OnPickupEffect` and `OnBuffStart` methods. [[1]](diffhunk://#diff-66ba5e56c3998c8d71a8d1f3b0fa4486a4e5f2d82edea06cf5bb8312601deb00L14-L15) [[2]](diffhunk://#diff-66ba5e56c3998c8d71a8d1f3b0fa4486a4e5f2d82edea06cf5bb8312601deb00L29-R27) [[3]](diffhunk://#diff-66ba5e56c3998c8d71a8d1f3b0fa4486a4e5f2d82edea06cf5bb8312601deb00L52-R50)
- Removed the buffStartSFX variable and its references from both ArmorPickup.cs and DamagePickup.cs.
- Updated ApplyDefenseBuff and ApplyDamageBuff calls to use null for the buff start sound effect, streamlining the code and improving clarity.